### PR TITLE
Fixing misalignment crash: width and height of bbox should be a multi…

### DIFF
--- a/src/kcf.cpp
+++ b/src/kcf.cpp
@@ -57,8 +57,8 @@ void KCF_Tracker::init(cv::Mat &img, const cv::Rect & bbox)
     }
 
     //compute win size + fit to fhog cell size
-    p_windows_size[0] = round(p_pose.w * (1. + p_padding) / p_cell_size) * p_cell_size;
-    p_windows_size[1] = round(p_pose.h * (1. + p_padding) / p_cell_size) * p_cell_size;
+    p_windows_size[0] = ceil(p_pose.w * (1. + p_padding) / (float)(p_cell_size*2)) * p_cell_size * 2;
+    p_windows_size[1] = ceil(p_pose.h * (1. + p_padding) / (float)(p_cell_size*2)) * p_cell_size * 2;
 
     p_scales.clear();
     if (m_use_scale)


### PR DESCRIPTION
…ple of (cell_size * 2)

Proposed ix for: https://github.com/vojirt/kcf/issues/10

Piotr's hog SSE calculations require the inputs to be 16 bytes aligned, or it crashes when trying to release R1 and R2 in gradientMex.cpp::fhog.
The relevant propagated parameters are the bounding box width and height that should be a multiple of (cell_size * 2).

You can see that when profiling the existing code with Valgrind, it complains on invalid read / writes. With the proposed fix those errors are gone.