### PR TITLE
Fix out of bound load and stores

### DIFF
--- a/src/piotr_fhog/gradientMex.cpp
+++ b/src/piotr_fhog/gradientMex.cpp
@@ -301,7 +301,7 @@ void fhog( float *M, float *O, float *H, int h, int w, int binSize,
   const int hb=h/binSize, wb=w/binSize, nb=hb*wb, nbo=nb*nOrients;
   float *N, *R1, *R2; int o, x;
   // compute unnormalized constrast sensitive histograms
-  R1 = (float*) wrCalloc(wb*hb*nOrients*2,sizeof(float));
+  R1 = (float*) wrCalloc(wb*hb*nOrients*2 + 2,sizeof(float));
   gradHist( M, O, R1, h, w, binSize, nOrients*2, softBin, true );
   // compute unnormalized contrast insensitive histograms
   R2 = (float*) wrCalloc(wb*hb*nOrients,sizeof(float));


### PR DESCRIPTION
FHoG calculation uses SSE instructions that operate on multiple values
at once. Therefore, depending on the size of the patch, it can happen
that the SSE instructions access (both for reading and writing) the
data outside of the image boundaries. This causes memory corruptions
and crashes.

We fix this problem by allocating more memory so that out-of-image
accesses always touch valid memory.