### PR TITLE
Fix numerical problems in sub_pixel_peak()

### DIFF
--- a/src/kcf.cpp
+++ b/src/kcf.cpp
@@ -618,9 +618,12 @@ cv::Point2f KCF_Tracker::sub_pixel_peak(cv::Point & max_loc, cv::Mat & response)
            d = x.at<float>(3), e = x.at<float>(4);
 
     cv::Point2f sub_peak(max_loc.x, max_loc.y);
-    if (b > 0 || b < 0) {
+    if (4 * a * c - b * b > 1e-5) {
         sub_peak.y = ((2.f * a * e) / b - d) / (b - (4 * a * c) / b);
         sub_peak.x = (-2 * c * sub_peak.y - e) / b;
+        if (fabs(sub_peak.x - max_loc.x) > 1 ||
+            fabs(sub_peak.y - max_loc.y) > 1)
+            sub_peak = max_loc;
     }
 
     return sub_peak;


### PR DESCRIPTION
Sometimes, finding the sub-pixel maximum fails (i.e. the solution is
very far from the maximal value pixel) and the tracked object is lost.

This happens when the quadratic function has no maximum. Therefore, we
use the solution only when we know that the function has a maximum and
also when the maximum lies within one pixel neighbourhood of the
maximal value pixel.